### PR TITLE
fix: use `as const` instead of enum

### DIFF
--- a/types/Nachocode.d.ts
+++ b/types/Nachocode.d.ts
@@ -837,14 +837,19 @@ declare global {
        * Native device permission types
        * @since 1.2.0
        */
-      export declare enum PermissionType {
-        CAMERA = 'camera',
-        LOCATION = 'location',
-        MICROPHONE = 'microphone',
-        PUSH = 'push',
-      }
+      // enum 대신 const object와 union type 사용
+      const PERMISSION_TYPES = {
+        CAMERA: 'camera',
+        LOCATION: 'location',
+        MICROPHONE: 'microphone',
+        PUSH: 'push',
+      } as const;
 
+      // union type으로 PermissionType 정의
+      type PermissionType =
+        (typeof PERMISSION_TYPES)[keyof typeof PERMISSION_TYPES];
       /**
+       *
        * @description
        * Checks whether the app user grants the specified permission or not.
        *


### PR DESCRIPTION
타입스크립트에선 이 방식이 여러모로 더 나은 유스케이스로 알고 있습니다.

- 런타임에서 더 작은 번들 사이즈 (enum은 IIFE로 컴파일됨)
- 타입 안정성 유지
- 문자열 리터럴 타입을 직접 사용 가능
- IDE 자동완성 지원
- Tree-shaking 가능 (타입스크립트 enum은 이걸 지원 안해서 안티 패턴으로 여겨지기도 함)